### PR TITLE
Fix sidebar logo path

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -40,7 +40,7 @@ const Sidebar = ({ collapsed, toggled, handleToggleSidebar }) => {
       <SidebarHeader>
         <div className="sidebar-header" onClick={() => navigate("/")}>
           <img
-            src="/Metro_logo.png"
+            src="/Metro_Logo.png"
             alt="Metro Logo"
             className="sidebar-logo"
           />


### PR DESCRIPTION
## Summary
- fix the logo path in `Sidebar` component to match the file name

## Testing
- `npm test --silent -- -w 0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b01c4a5bc83208a3355ff7e6af359